### PR TITLE
run the validate-wheelhouse charm on every supported charm series

### DIFF
--- a/.github/workflows/validate-wheelhouse.yaml
+++ b/.github/workflows/validate-wheelhouse.yaml
@@ -2,11 +2,20 @@ name: Validate Wheelhouse
 
 on:
   workflow_call:
+    inputs:
+      series:
+        description: 'Matrix of ubuntu versions'
+        default: "['bionic', 'focal', 'jammy']"
+        required: false
+        type: string
   
 jobs:
   validate-wheelhouse:
     name: Validate Wheelhouse
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        series: ${{ fromJson(inputs.series) }}
+    runs-on: ubuntu-${{ matrix.series }}
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/validate-wheelhouse.yaml
+++ b/.github/workflows/validate-wheelhouse.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       series:
         description: 'Matrix of ubuntu versions'
-        default: "['bionic', 'focal', 'jammy']"
+        default: "['18.04', '20.04', '22.04']"
         required: false
         type: string
   


### PR DESCRIPTION
change the validate-workflow to attempt installing the built charm's wheelhouse on all supported series of the charm. 

series based on the [list](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on)