### PR TITLE
Bump `actions/checkout` && `actions/setup-python` versions

### DIFF
--- a/.github/workflows/lint-unit.yaml
+++ b/.github/workflows/lint-unit.yaml
@@ -27,9 +27,9 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install Dependencies

--- a/.github/workflows/validate-wheelhouse.yaml
+++ b/.github/workflows/validate-wheelhouse.yaml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-${{ matrix.series }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
     - name: Install Dependencies
       run: |
         pip install tox


### PR DESCRIPTION
## Changes
Node.js 12 actions are [deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). This PR updates the `checkout` and `setup-python` versions in the reusable workflows to address this issue.