### PR TITLE
updated callable workflows to default to jammy, and drop python 3.6

### DIFF
--- a/.github/workflows/lint-unit.yaml
+++ b/.github/workflows/lint-unit.yaml
@@ -3,9 +3,14 @@ name: Lint-Unit
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'Which ubuntu series should be used for the runner'
+        default: "ubuntu-22.04"
+        required: false
+        type: string
       python:
         description: 'Matrix of python versions formatted as a JSON array'
-        default: "['3.6', '3.7', '3.8', '3.9', '3.10']"
+        default: "['3.7', '3.8', '3.9', '3.10', '3.11']"
         required: false
         type: string
       working-directory:
@@ -18,7 +23,7 @@ on:
 jobs:
   lint-unit:
     name: Lint and Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     strategy:
       matrix:
         python: ${{ fromJson(inputs.python) }}

--- a/.github/workflows/validate-wheelhouse.yaml
+++ b/.github/workflows/validate-wheelhouse.yaml
@@ -3,9 +3,14 @@ name: Validate Wheelhouse
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'Which ubuntu series should be used for the runner'
+        default: "ubuntu-22.04"
+        required: false
+        type: string
       python:
         description: 'Matrix of python versions'
-        default: "['3.6', '3.8', '3.10']"
+        default: "['3.8', '3.10']"
         required: false
         type: string
   
@@ -15,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python: ${{ fromJson(inputs.python) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
     - name: Check out code
       uses: actions/checkout@v3


### PR DESCRIPTION
`ubuntu-latest` now is defaulted to `ubuntu-22.04`, which no longer supports python 3.6
https://github.com/actions/runner-images/issues/6399

Therefore we should default to not using python36 and be specific about the type of runners used. 