### PR TITLE
Update to LTS python versions, and run on noble

### DIFF
--- a/.github/workflows/lint-unit.yaml
+++ b/.github/workflows/lint-unit.yaml
@@ -5,12 +5,12 @@ on:
     inputs:
       runs-on:
         description: 'Which ubuntu series should be used for the runner'
-        default: "ubuntu-22.04"
+        default: "ubuntu-24.04"
         required: false
         type: string
       python:
         description: 'Matrix of python versions formatted as a JSON array'
-        default: "['3.7', '3.8', '3.9', '3.10', '3.11']"
+        default: "['3.8', '3.10', '3.12']"
         required: false
         type: string
       working-directory:

--- a/.github/workflows/validate-wheelhouse.yaml
+++ b/.github/workflows/validate-wheelhouse.yaml
@@ -5,12 +5,12 @@ on:
     inputs:
       runs-on:
         description: 'Which ubuntu series should be used for the runner'
-        default: "ubuntu-22.04"
+        default: "ubuntu-24.04"
         required: false
         type: string
       python:
         description: 'Matrix of python versions'
-        default: "['3.8', '3.10']"
+        default: "['3.8', '3.10', '3.12']"
         required: false
         type: string
         


### PR DESCRIPTION
### Overview

Run actions on noble, use only python versions on ubuntu LTS versions 

| focal | jammy | noble |
| --- | --- | --- |
| 3.8 | 3.10 | 3.12 |