### PR TITLE
Optionally install tox-uv

### DIFF
--- a/.github/workflows/lint-unit.yaml
+++ b/.github/workflows/lint-unit.yaml
@@ -5,12 +5,12 @@ on:
     inputs:
       runs-on:
         description: 'Which ubuntu series should be used for the runner'
-        default: "ubuntu-22.04"
+        default: "ubuntu-24.04"
         required: false
         type: string
       python:
         description: 'Matrix of python versions formatted as a JSON array'
-        default: "['3.7', '3.8', '3.9', '3.10', '3.11']"
+        default: "['3.8', '3.10', '3.12']"
         required: false
         type: string
       working-directory:
@@ -18,7 +18,11 @@ on:
         default: './'
         required: false
         type: string
-
+      with-uv:
+        description: 'Whether to run with tox-uv'
+        default: false
+        required: false
+        type: boolean
   
 jobs:
   lint-unit:
@@ -33,13 +37,26 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      # Setup using Python
       - name: Setup Python
         uses: actions/setup-python@v5
+        if: ${{ inputs.with-uv == false }}
         with:
           python-version: ${{ matrix.python }}
-      - name: Install Dependencies
-        run: |
-          pip install tox
+      - name: Install Tox
+        if: ${{ inputs.with-uv == false }}
+        run: pip install tox
+
+      # Setup using UV
+      - uses: astral-sh/setup-uv@v5
+        if: ${{ inputs.with-uv == true }}
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox with UV
+        if: ${{ inputs.with-uv == true }}
+        run: uv tool install tox --with tox-uv
+
       - name: Lint
         run: tox -vve lint
       - name: Unit Tests

--- a/.github/workflows/validate-wheelhouse.yaml
+++ b/.github/workflows/validate-wheelhouse.yaml
@@ -5,14 +5,19 @@ on:
     inputs:
       runs-on:
         description: 'Which ubuntu series should be used for the runner'
-        default: "ubuntu-22.04"
+        default: "ubuntu-24.04"
         required: false
         type: string
       python:
         description: 'Matrix of python versions'
-        default: "['3.8', '3.10']"
+        default: "['3.8', '3.10', '3.12']"
         required: false
         type: string
+      with-uv:
+        description: 'Whether to run with tox-uv'
+        default: false
+        required: false
+        type: boolean
         
 jobs:
   validate-wheelhouse:
@@ -24,13 +29,30 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+
+    # Setup using Python
     - name: Setup Python
       uses: actions/setup-python@v5
+      if: ${{ inputs.with-uv == false }}
       with:
         python-version: ${{ matrix.python }}
-    - name: Install Dependencies
+    - name: Install Tox
+      if: ${{ inputs.with-uv == false }}
       run: |
         pip install tox
         sudo snap install charm --classic
+
+    # Setup using UV
+    - name: Setup Astral UV
+      uses: astral-sh/setup-uv@v5
+      if: ${{ inputs.with-uv == true }}
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install tox with UV
+      if: ${{ inputs.with-uv == true }}
+      run: |
+        uv tool install tox --with tox-uv
+        sudo snap install charm --classic
+
     - name: Run validate-wheelhouse
       run: tox -vve validate-wheelhouse


### PR DESCRIPTION
Support lint/unit/validate-wheelhouse tests by using tox-uv. 

With tox-uv, pip is replaced with uv increasing speeds of the associated tests.